### PR TITLE
Save start time

### DIFF
--- a/contracts/test/unit_tests/1_test_admin_updates.js
+++ b/contracts/test/unit_tests/1_test_admin_updates.js
@@ -48,11 +48,12 @@ contract("Update globals as admin", function(accounts) {
     }),
     it("Update interest decimals", async function() {
         var oldDecimals = await contract.interestDecimals.call()
+        var newNumberOfDecimals = web3.utils.toBN('8')
         var newDecimals = web3.utils.toBN('100000000')
         var newBaseInterest = (await contract.baseInterest.call()).mul(newDecimals).div(oldDecimals)
         var newExtraInterest = (await contract.extraInterest.call()).mul(newDecimals).div(oldDecimals)
-        await truffleAssert.reverts(contract.updateInterestDecimals(newDecimals, {from: nonOwnerAddress}))
-        await contract.updateInterestDecimals(newDecimals, {from: ownerAddress})
+        await truffleAssert.reverts(contract.updateInterestDecimals(newNumberOfDecimals, {from: nonOwnerAddress}))
+        await contract.updateInterestDecimals(newNumberOfDecimals, {from: ownerAddress})
         assert.equal(newDecimals.toString(), (await contract.interestDecimals.call()).toString())
         assert.equal(newBaseInterest.toString(), (await contract.baseInterest.call()).toString())
         assert.equal(newExtraInterest.toString(), (await contract.extraInterest.call()).toString())

--- a/contracts/test/unit_tests/2_test_staking.js
+++ b/contracts/test/unit_tests/2_test_staking.js
@@ -86,6 +86,10 @@ contract("Staking", function(accounts) {
         // Check if the staking balance of the stakeholder was updated
         assert.equal((await contract.stakeholders.call(staker)).stakingBalance.toString(), stake)
 
+        // Check if the start date of the stakeholder was updated
+        assert.equal((await contract.stakeholders.call(staker)).startDate.toString(), await truffleHelpers.time.latest())
+
+
     })
 
 })


### PR DESCRIPTION
## Changes:

-A dded start time for each stakeholder. Time is set when their stake becomes greater than 0 (in the `stake` function) and resets when all funds are withdrawn from the contract (in the `withdraw` function).
- Adjust `updateDecimals` to be a factor of 10 by taking the number of decimals instead of the divisor. For example, if you want to have 3 decimals for the interest rate, you needed to provide '1000' as input. Now, you  have to provide '3', which will be converted into 10**3 = 1000.
- Updated tests