### PR TITLE
Working version V0.2.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,25 @@ This repository contains the source code for the staking contract created for th
 * The **time** staked by the stakeholder, as rewards do compound. Rewards of previous periods are automatically added to the users staking balance.
 * The **user weight** or **user level** of the stakeholder, which is determined based on off-chain actions.
 
-## Reward calculation
+## Table of contents
+
+- [Envoy staking contract](#envoy-staking-contract)
+  - [Table of contents](#table-of-contents)
+  - [Staking logic](#staking-logic)
+    - [Reward calculation](#reward-calculation)
+    - [Increasing the off-chain user level](#increasing-the-off-chain-user-level)
+    - [Adjusting stake or increase weights in between staking periods](#adjusting-stake-or-increase-weights-in-between-staking-periods)
+    - [Withdrawing funds](#withdrawing-funds)
+    - [Example](#example)
+      - [Period 1](#period-1)
+      - [Period 2](#period-2)
+      - [Period 3](#period-3)
+      - [Period 4](#period-4)
+  - [Contract implementation](#contract-implementation)
+
+## Staking logic
+
+### Reward calculation
 
 The goal of the contract is to periodically pay out a constant reward amongst the stakeholders. The period is hardcoded and cannot be altered after deployment, the reward per period can be adjusted by the contract owner. This allows increasing the rewards when times are good and profits are shared with the community. The complexity of the contract lies in a correct distribution.
 
@@ -37,7 +55,7 @@ With:
 Applying the formula for each stakeholder and summing up the results exactly equals the `rewardsPerPeriod` value.
 To receive the ENVOY tokens earned, stakeholders must manually claim them from the contract after one or multiple staking periods are over.
 
-## Increasing the off-chain user level
+### Increasing the off-chain user level
 
 The interest of the stakeholder is dependent on a weight based on user level, assigned by ENVOY off-chain. The stakeholders have to manually update their level themselves. The steps to level up are:
 
@@ -45,36 +63,36 @@ The interest of the stakeholder is dependent on a weight based on user level, as
 * Once a certain level is used, a signature for a certain level can be requested. This signature will contain the stakeholders address, the level he is at and the staking contract. It will be singed by a private key of Envoy.
 * The stakeholder provides the signature in the on-chain function to level up. The smart contract verifies if this signature for the specific input was signed by the Envoy key. If the signature is valid, the stakeholder's interest weight increases. If a malicious signature is used, the transaction will be reverted.
 
-## Adjusting stake or increase weights in between staking periods
+### Adjusting stake or increase weights in between staking periods
 
 When people want to increase the amount staked, increase their user level or withdrawl funds, it probably happens in the middle of a staking period. For adjusting the stake, the update is *delayed* and will be applied from the *next* period. If a user increases his stake, the current period will still use the old staked amount for reward calculation. Starting from next period, the new staked amount will be used. This is to avoid misuse of last-minute stakers gaining full rewards.
 
 Updating the user weight will be applied immediately. This is because users who are rewarded with a higher weight deserve the update and the feature cannot be misused.
 
-## Withdrawing funds
+### Withdrawing funds
 
 When people want to stop staking, they can request a withdrawl for a certain amount. The amount can be a part of the staking balance and will be capped by the total staking balance. The amount will be reduced from the balance immediately. The funds are not considered for rewards anymore. However, the actual tokens remain in the contract until a cooldown period is over. After the cooldown, the stakeholder can safely transfer the tokens to his wallet again. The aim of the measure is to avoid people gaining big rewards and immediately dumping the token afterwards. The cooldown period can be set by the contract owner.
 
-## Example
+### Example
 
 An diagram with an example of the staking contract can be in this
-[link](https://viewer.diagrams.net/?tags=%7B%7D&highlight=0000ff&edit=_blank&layers=1&nav=1#G1G9_XUMuq-GtGyMKJSU8PSFtl_lu2kOql). In the example, there are 4 stakers. In reality, there might be more.
+[link](https://viewer.diagrams.net/?tags=%7B%7D&highlight=0000ff&edit=_blank&layers=1&nav=1#G1G9_XUMuq-GtGyMKJSU8PSFtl_lu2kOql). In the example, there are 4 stakers. In reality, there are probably more.
 
-### Period 1
+#### Period 1
 
 In the first period, the reward per period is set to 30. 3 stakeholders invest for 50, 30 and 20 tokens. In this period, no rewards are distributed as nothing was staked the period before.
 
-### Period 2
+#### Period 2
 
 The first 3 stakers start their first full rewarding period. From this period and onwards they will start gaining rewards. A forth stakers joins the system for 50 ENV.
 
-### Period 3
+#### Period 3
 
 Stakeholder 1 updates his weight from 1 to 2. The update is done instantly, from this period and onwards rewards will be calculated with weight 3. His rewards with the old weight are calculated for the previous periods.
 
 In period 1, the staker did not earn anything as nothing was staked. In period 2, the staker had 50 from a total pool of 100 tokens staked with a reward per period of 30, so the staker receives 15 tokens. Period 3 is ongoing, so no rewards are rewarded yet. The next reward calculation in later periods will start from period 3 for stakeholder 1.
 
-### Period 4
+#### Period 4
 
 Stakeholder 2 stakes another 50. As with each user update, the rewards using previous state is rewarded first before updating the values.
 
@@ -85,3 +103,27 @@ Stakeholder 2 stakes another 50. As with each user update, the rewards using pre
 Combined, stakeholder 2 receives 13.77 tokens.
 
 The update of the new stake is not done instantly. The rewards for this period will be calculated using the *old* stake. From period 5 and onwards, the new stake will be used. Stakeholders need to have the stake for a full period before it is rewarded.
+
+## Contract implementation
+
+The contract is implemented to keep track of two states in 2 mappings of structs:
+
+* The state of each staker, mapping the stakeholder's address to a struct containing:
+
+  * The **staking balance** or amount staked
+  * The **new staking balance**, the amount that is staked but not yet used in the reward calculation because it was not staked for a full period.
+  * The **weight** or level of each stakeholder to multiply the staking balance with in the reward calculation
+  * The **start date** or date the staker joined
+  * The date the stakeholder claimed the last rewards
+  * The **release date** on which the stakeholder is able to withdraw the staked funds
+  * The amount the staker can withdraw after the release date
+
+* The state of each interval for which rewards are divided, mapping the sequential number of the reward period to a struct containing:
+
+  * The **reward per period** or amount to distribute over all   stakeholders based on their weighted stake
+  * The **total staking balance** for each weight, kept in a mapping. It is kept in a small mapping instead of a single integer to be able to calculate the total weighted reward each period.
+  * The **total new staking balance** for each weight in a mapping, similar to the new staking balance field in the struct for single stakeholders
+  * The **total rewards claimed** for each weight, keeping track of how many rewards were actually claimed (and indirectly how many rewards still need to be distributed.
+
+  The key is how many reward periods have passed during the life time of the contract. The current period is calculated based on two state variables (the **start time of the contract** and the **duration** of a reward period set in the constructor) and the current block time. The formula is the difference of the start time and the current time,  divided by the duration of a period. The formula is triggered by the `currentPeriod` function. When a period ends, a struct for the next period will be initialized in the mapping, based on the previous period and all changes to be applied. This happens in the `handleNewPeriod` function. The function can be triggered manually, but is also triggerd when users interact with the contract to update the state (for example when .staking, updating weight, claiming or initializing a withdraw).
+  

--- a/contracts/contracts/EnvoyStakingv2 - constant total reward.sol
+++ b/contracts/contracts/EnvoyStakingv2 - constant total reward.sol
@@ -33,11 +33,6 @@ contract EnvoyStakingV2 is Ownable {
     }
 
     /** Struct containing the state of each reward period.
-    Normally, for each period of duration `rewardPeriodDuration`,
-    a new struct is added when users interact with the contract.
-    If no interaction with the smart contract takes place,
-    the state will be used for multiple periods between
-    RewardPeriod.startDate and RewardPeriod.endDate.
     */
     struct RewardPeriod {
         uint rewardPerPeriod; // amount to distribute over stakeholders
@@ -66,17 +61,27 @@ contract EnvoyStakingV2 is Ownable {
     uint public cooldown = 7 days; // Length between withdrawal request and actual withdrawal is possible
 
 
-    string private _name = "ENVOY - STAKING"; // Used for ERC20 compatibility
-    string private _symbol = "ENV-S"; // Used for ERC20 compatibility
+    string public name = "ENVOY - STAKING"; // Used for ERC20 compatibility
+    string public symbol = "ENV-S"; // Used for ERC20 compatibility
 
-    constructor(address signatureAddress_, address stakingTokenAddress) {
+    constructor(uint maxNumberOfPeriods_, // Used to cap the end date in the reward calculation
+                uint rewardPeriodDuration_, // Length in between reward distribution
+                uint cooldown_,
+                uint rewardPerPeriod_,
+                address signatureAddress_,
+                address stakingTokenAddress) {
+        maxNumberOfPeriods = maxNumberOfPeriods_;
+        rewardPeriodDuration = rewardPeriodDuration_;
+        cooldown = cooldown_;
+
+
         signatureAddress = signatureAddress_;
         stakingToken = IERC20(stakingTokenAddress);
 
         startDate = block.timestamp;            
         
         // Initialise the first reward period in the sequence
-        rewardPeriods[0].rewardPerPeriod = 958000 * 10**18;
+        rewardPeriods[0].rewardPerPeriod = rewardPerPeriod_;
     }
 
     /**

--- a/contracts/contracts/EnvoyStakingv2 - constant total reward.sol
+++ b/contracts/contracts/EnvoyStakingv2 - constant total reward.sol
@@ -40,8 +40,6 @@ contract EnvoyStakingV2 is Ownable {
     RewardPeriod.startDate and RewardPeriod.endDate.
     */
     struct RewardPeriod {
-        // uint startDate; // First period for which this state applies
-        // uint endDate; // Last period for which this state applies
         uint rewardPerPeriod; // amount to distribute over stakeholders
         mapping (uint => uint) totalStakingBalance; // Mapping weight to stake amount of tokens staked
         mapping (uint => uint) totalNewStake; // Tokens staked in this period to be added in the next one.

--- a/contracts/contracts/EnvoyStakingv2 - constant total reward.sol
+++ b/contracts/contracts/EnvoyStakingv2 - constant total reward.sol
@@ -64,8 +64,8 @@ contract EnvoyStakingV2 is Ownable {
 
     uint public startDate; // Used to calculate how many periods have passed
     uint public maxNumberOfPeriods = 1095; // Used to cap the end date in the reward calculation
-    uint public rewardPeriodDuration= 7 days; // Length in between reward distribution
-    uint public cooldown = 1 days; // Length between withdrawal request and actual withdrawal is possible
+    uint public rewardPeriodDuration= 1 days; // Length in between reward distribution
+    uint public cooldown = 7 days; // Length between withdrawal request and actual withdrawal is possible
 
 
     string private _name = "ENVOY - STAKING"; // Used for ERC20 compatibility

--- a/contracts/migrations/1_migrate.js
+++ b/contracts/migrations/1_migrate.js
@@ -17,5 +17,11 @@ module.exports = async function (deployer, network, accounts) {
     const token = await TestToken.deployed()
     tokenAddress = token.address
   }
-  await deployer.deploy(EnvoyStaking, signatureAddress, tokenAddress);    
+  await deployer.deploy(EnvoyStaking,
+                        maxNumberOfPeriods = web3.utils.toBN(1095),
+                        rewardPeriodDuration = web3.utils.toBN(86400),
+                        cooldown = web3.utils.toBN(86400 * 7),
+                        rewardPerPeriod = web3.utils.toBN('135000000000000000000000'),
+                        signatureAddress,
+                        tokenAddress);    
 };

--- a/contracts/test/v2/integration_tests/1_four_staker_example.js
+++ b/contracts/test/v2/integration_tests/1_four_staker_example.js
@@ -47,7 +47,11 @@ contract("Rewarding", function(accounts) {
 
         // Make sure contracts are deployed
         token = await TestToken.new();
-        contract = await EnvoyStaking.new(signatureAddress, token.address);
+        contract = await EnvoyStaking.new(maxNumberOfPeriods = web3.utils.toBN(1095),
+            rewardPeriodDuration = web3.utils.toBN(86400),
+            cooldown = web3.utils.toBN(86400 * 7),
+            rewardPerPeriod = web3.utils.toBN('135000000000000000000000'),
+            signatureAddress, token.address);
         
         // Make sure the contract and accounts have funds
         for(let account in accounts){

--- a/contracts/test/v2/integration_tests/1_four_staker_example.js
+++ b/contracts/test/v2/integration_tests/1_four_staker_example.js
@@ -265,10 +265,10 @@ contract("Rewarding", function(accounts) {
         console.log('period used', (await contract.stakeholders.call(staker1)).rewardPeriod.toString(), (await contract.stakeholders.call(staker2)).rewardPeriod.toString(), (await contract.stakeholders.call(staker3)).rewardPeriod.toString(), (await contract.stakeholders.call(staker4)).rewardPeriod.toString())
         console.log('last claimed', (await contract.stakeholders.call(staker1)).lastClaimed.toString(), (await contract.stakeholders.call(staker2)).lastClaimed.toString(), (await contract.stakeholders.call(staker3)).lastClaimed.toString(), (await contract.stakeholders.call(staker4)).lastClaimed.toString())
         
-        console.log('start, end, twsb, tsb, nsb, wnsb, rc')
+        console.log('start, end, tqwsb, twsb, tsb, rc, ntqwsb, ntwsb, ntsb')
         for(var i=0;i<(await contract.getRewardPeriodsLength()).toNumber();i++){
             c = await contract.rewardPeriods.call(i.toString())
-            console.log(i, c.startDate.toString(), c.endDate.toString(), web3.utils.fromWei(c.totalWeightedStakingBalance), web3.utils.fromWei(c.totalStakingBalance), web3.utils.fromWei(c.totalNewStake), web3.utils.fromWei(c.totalNewWeightedStake), web3.utils.fromWei(c.totalWeightedRewardsClaimed))
+            console.log(i, c.startDate.toString(), c.endDate.toString(), web3.utils.fromWei(c.totalQuadraticWeightedStakingBalance),web3.utils.fromWei(c.totalWeightedStakingBalance), web3.utils.fromWei(c.totalStakingBalance), web3.utils.fromWei(c.totalWeightedRewardsClaimed), web3.utils.fromWei(c.totalNewQuadraticWeightedStake), web3.utils.fromWei(c.totalNewWeightedStake), web3.utils.fromWei(c.totalNewStake))
         }
 
         await contract.claimRewards(false, {from: staker2})
@@ -286,8 +286,8 @@ contract("Rewarding", function(accounts) {
         
         // Amount to withdraw calculated with:
         // calculation3 = (await contract.calculateRewards.call(staker3))
-        // console.log('staker3: ', web3.utils.toBN(calculation3.stakeholder.stakingBalance).add(calculation3.reward).toString())
-        var amountToWithdraw = web3.utils.toBN('32236165464601054367')
+        console.log('staker3: ', web3.utils.toBN(calculation3.stakeholder.stakingBalance).add(calculation3.reward).toString())
+        var amountToWithdraw = web3.utils.toBN('32201938927377201726')
 
         // Requesting to withdrawl more than stake + rewards
         await contract.requestWithdrawal(web3.utils.toWei('50000'), true, {from: staker3})

--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -84,8 +84,8 @@ module.exports = {
     solc: {
       version: "0.8.0",
       optimizer: {
-        enabled: true,
-        runs: 1500
+        // enabled: true,
+        // runs: 200
       }
     }
   },


### PR DESCRIPTION
The logic documented now works.

Big code refactoring:
* Total balance per period is kept per weight in a mapping instead of in a single integer
* Weighted balance is not saved in state but calculated based on the mapping with totals
* **All** rewards are automatically added tot the staking balance when a period is finished, not only **claimed** rewards. This keeps the reward calculation cleaner
* Reward periods are not bundled in the same struct anymore with a start and end period, each period has its own struct.
* Many changes in the reward calculation itself
* A maximum amount of iterations is set on the reward calculation (currently 3 years, adjustable)

Integration test gives good results but needs to be more in depth.
Unit tests are broken as they use old API and logic. To be done later.
Docs are updated but not finalized.